### PR TITLE
4-12 sprint - Breaking Changes from Dependency Upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "colors": "^1.4.0",
         "connect-mongodb-session": "^3.1.1",
         "cookie-parser": "^1.4.6",
+        "csurf": "^1.11.0",
         "daisyui": "^2.51.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -2927,6 +2928,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/css-selector-tokenizer": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
@@ -2945,6 +2959,73 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "Please use another csrf package",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "node_modules/csurf/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/daisyui": {
@@ -7497,6 +7578,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8713,6 +8799,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "optional": true
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "colors": "^1.4.0",
     "connect-mongodb-session": "^3.1.1",
     "cookie-parser": "^1.4.6",
+    "csurf": "^1.11.0",
     "daisyui": "^2.51.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/src/config/dependencies.js
+++ b/src/config/dependencies.js
@@ -1,55 +1,45 @@
 // dependencies.js
-
-import bodyParser from 'body-parser'
-import helmet from 'helmet'
+// dev depenancies
 import colors from 'colors'
-import connectMongoDBSession from 'connect-mongodb-session'
-import cookieParser from 'cookie-parser'
 import dotenv from 'dotenv'
+import morgan from 'morgan'
+// db depenancies
+import connectMongoDBSession from 'connect-mongodb-session'
+import connectDB from './db.js'
+
+// express depenancies
+import cookieParser from 'cookie-parser'
+import csurf from 'csurf'
 import express from 'express'
 import fileUpload from 'express-fileupload'
 import flash from 'express-flash'
+import session from 'express-session'
+import helmet from 'helmet'
+// handlebars depenancies
+import { create } from 'express-handlebars' // templating engine
 import handlebarsHelpers from 'handlebars-helpers'
 import paginate from 'handlebars-paginate'
-import morgan from 'morgan'
+// auth depenancies
 import passport from 'passport'
-import csurf from 'csurf'
-import connectDB from './config/db.js'
-import passportConfig from './config/passport.js'
-import { rateLimiter } from './config/util.config.js'
-import { checkAuth, isManager } from './middleware/auth.js'
-import { dashboardRouter } from './routes/dashboard.routes.js'
-import { indexRouter } from './routes/index.routes.js'
-import { settingsRouter } from './routes/settings/index.routes.js'
-import { toolRouter } from './routes/tool.routes.js'
-import { listCategoryNames, getCategoryName } from './middleware/category.js'
-import { isSelected } from './middleware/util.js'
+import passportConfig from './passport.js'
+import { checkAuth, isManager } from '../middleware/auth.js'
+// utility depenancies
+import { getCategoryName, listCategoryNames } from '../middleware/category.js'
+import { isSelected } from '../middleware/util.js'
+import { rateLimiter } from './util.config.js'
+// routers
+import { dashboardRouter } from '../routes/dashboard.routes.js'
+import { indexRouter } from '../routes/index.routes.js'
+import { settingsRouter } from '../routes/settings/index.routes.js'
+import { toolRouter } from '../routes/tool.routes.js'
+import { userRouter } from '../routes/user.routes.js'
 
 export {
-  bodyParser,
-  helmet,
-  colors,
-  connectMongoDBSession,
-  cookieParser,
-  dotenv,
+  checkAuth, colors, connectDB, connectMongoDBSession,
+  cookieParser, create, csurf, dashboardRouter, dotenv,
   express,
   fileUpload,
-  flash,
-  handlebarsHelpers,
-  paginate,
-  morgan,
-  passport,
-  csurf,
-  connectDB,
-  passportConfig,
-  rateLimiter,
-  checkAuth,
-  isManager,
-  dashboardRouter,
-  indexRouter,
-  settingsRouter,
-  toolRouter,
-  listCategoryNames,
-  getCategoryName,
-  isSelected
+  flash, getCategoryName, handlebarsHelpers, helmet, indexRouter, isManager, isSelected, listCategoryNames, morgan, paginate, passport, passportConfig,
+  rateLimiter, session, settingsRouter, userRouter,
+  toolRouter
 }

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -31,9 +31,9 @@ const passportConfig = (app) => {
     done(null, user._id)
   })
 
-  passport.deserializeUser(function (id, done) {
+  passport.deserializeUser(async function (id, done) {
     try {
-      const user = User.findOne(id)
+      const user = await User.findById(id).lean().exec()
       done(null, user)
     } catch (err) {
       done(err)

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -32,9 +32,12 @@ const passportConfig = (app) => {
   })
 
   passport.deserializeUser(function (id, done) {
-    User.findById(id, function (err, user) {
-      done(err, user)
-    })
+    try {
+      const user = User.findOne(id)
+      done(null, user)
+    } catch (err) {
+      done(err)
+    }
   })
 }
 

--- a/src/middleware/util.js
+++ b/src/middleware/util.js
@@ -58,7 +58,6 @@ function sanitize (string) {
  * It will mutate the req.body
  **/
 export function sanitizeReqBody (req, _res, next) {
-  console.info('[MW] sanitizeReqBody-in'.red.underline)
   for (const key in req.body) {
     req.body[key] = sanitize(req.body[key])
   }

--- a/src/server.js
+++ b/src/server.js
@@ -1,32 +1,32 @@
 // server.js
-
 import {
-  bodyParser,
-  helmet,
-  colors,
+  checkAuth,
+  connectDB,
   connectMongoDBSession,
   cookieParser,
+  create,
+  csurf,
+  dashboardRouter,
   dotenv,
   express,
   fileUpload,
   flash,
+  getCategoryName,
   handlebarsHelpers,
-  paginate,
+  helmet,
+  indexRouter,
+  isManager,
+  isSelected,
+  listCategoryNames,
   morgan,
+  paginate,
   passport,
-  csurf,
-  connectDB,
   passportConfig,
   rateLimiter,
-  checkAuth,
-  isManager,
-  dashboardRouter,
-  indexRouter,
+  session,
   settingsRouter,
   toolRouter,
-  listCategoryNames,
-  getCategoryName,
-  isSelected
+  userRouter
 } from './config/dependencies.js'
 
 // use the imported dependencies as needed in the server.js file

--- a/src/server.js
+++ b/src/server.js
@@ -96,12 +96,12 @@ app.set('view engine', '.hbs')
 app.set('views', './src/views')
 
 // Express Middleware
-app.use(csurf({ cookie: true })) // Cross Site Request Forgery protection middleware
+app.use(cookieParser())
+if (process.NODE_ENV === 'PRODUCTION') app.use(csurf({ cookie: true })) // Cross Site Request Forgery protection middleware
 app.use(express.static('./src/public')) // Serve Static Files
 app.use(express.json()) // JSON Body Parser
 app.use(fileUpload())
 app.use(express.urlencoded({ extended: false })) // Parse URL-encoded values
-app.use(cookieParser())
 app.use(session(sessionConfig))
 app.use(flash())
 // Passport


### PR DESCRIPTION
Moved Imports to a separate file to make server.js easier to read

set up conditionals for dev/prod csrf usage so we can keep prod builds save while still using unsigned-inline scripts in dev

moved user serialization from callback functions to async await.

removed additional logging from sanitize function as it's working as expected and the logging doesn't tell us anything helpful.