### PR TITLE
Tool Table Componentization

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node ./src/server.js",
-    "dev": "concurrently \"nodemon ./src/server.js\" \"npx tailwindcss -c ./src/config/tailwind.config.js --postcss ./src/config/postcss.config.cjs  -i ./src/public/css/tailwind.css -o ./src/public/css/style.css -w\"",
+    "dev": "nodemon ./src/server.js",
     "build:css": "npx tailwindcss -c ./src/config/tailwind.config.js --postcss ./src/config/postcss.config.cjs  -i ./src/public/css/tailwind.css -o ./src/public/css/style.css",
     "watch:css": "npx tailwindcss -c ./src/config/tailwind.config.js --postcss ./src/config/postcss.config.cjs  -i ./src/public/css/tailwind.css -o ./src/public/css/style.css -w"
   },

--- a/src/middleware/tool.js
+++ b/src/middleware/tool.js
@@ -64,23 +64,50 @@ async function getToolByID (req, res, next) {
  * @returns {array}
  */
 async function searchTools (req, res, next) {
-  console.info('[MW] searchTools-in'.bgBlue.white)
+  console.info('[MW] searchTools-in'.bgBlue.white + req.body)
   const { sortField, sortOrder } = req.user.preferences
   const { searchBy, searchTerm } = req.body
-  const tools = await Tool.find({
-    [searchBy]: { $regex: searchTerm, $options: 'i' }
-  }).sort({ [sortField]: sortOrder })
+  let result
+  console.table(req.body)
+  switch (searchBy) {
+    case 'serviceAssignment':
+      result = await Tool.where('serviceAssignment')
+        .equals(searchTerm)
+        .sort({ [sortField]: sortOrder })
+        .exec()
+      break
+    case 'category':
+      result = await Tool.where('category')
+        .equals(searchTerm)
+        .sort({ [sortField]: sortOrder })
+        .exec()
+      break
+    case 'status':
+      result = await Tool.where('status')
+        .equals(searchTerm)
+        .sort({ [sortField]: sortOrder })
+        .exec()
+      break
+    default:
+      result = await Tool.where(searchBy)
+        .regex(`${searchTerm}/i`)
+        .sort({ [sortField]: sortOrder })
+        .exec()
+      break
+  }
+  console.log(result)
   const { trimmedData, pageCount, targetPage } = paginate(
-    tools,
+    result,
     req.query.p,
     req.user.preferences.pageSize
   )
   res.locals.pagination = { page: targetPage, pageCount } // pagination
   res.locals.tools = trimmedData // array of tools
-  res.locals.message = `Search results for ${searchBy} : ${searchTerm}`
+  res.locals.searchTerm = searchTerm
   console.info('[MW] searchTools-out'.bgWhite.blue)
   return next()
 }
+
 /**
  *
  * @param {object} req.body The tool object to create

--- a/src/middleware/tool.js
+++ b/src/middleware/tool.js
@@ -77,7 +77,7 @@ async function searchTools (req, res, next) {
   )
   res.locals.pagination = { page: targetPage, pageCount } // pagination
   res.locals.tools = trimmedData // array of tools
-  res.locals.searchTerm = searchTerm
+  res.locals.message = `Search results for ${searchBy} : ${searchTerm}`
   console.info('[MW] searchTools-out'.bgWhite.blue)
   return next()
 }

--- a/src/middleware/tool.js
+++ b/src/middleware/tool.js
@@ -77,7 +77,7 @@ async function searchTools (req, res, next) {
   )
   res.locals.pagination = { page: targetPage, pageCount } // pagination
   res.locals.tools = trimmedData // array of tools
-  res.locals.message = `Search results for ${searchBy} : ${searchTerm}`
+  res.locals.searchTerm = searchTerm
   console.info('[MW] searchTools-out'.bgWhite.blue)
   return next()
 }

--- a/src/middleware/util.js
+++ b/src/middleware/util.js
@@ -11,6 +11,7 @@ sanitize
 *createAccountLimiter
 *csvFileToEntries
 *getPackageVersion
+*hoistSearchParamsToBody
 */
 
 import rateLimit from 'express-rate-limit'
@@ -118,9 +119,18 @@ export function csvFileToEntries (file) {
     .replace("'", '')
     .replaceAll('"', '')
     .split(/\r?\n/)
-    .map(row => row.split(','))
+    .map((row) => row.split(','))
 }
 
 export function getPackageVersion () {
   return process.env.npm_package_version
+}
+
+export function hoistSearchParamsToBody (req, _res, next) {
+  if (req.body.searchBy === undefined) {
+    const { searchBy, searchTerm } = req.query
+    req.body.searchBy = searchBy
+    req.body.searchTerm = searchTerm
+  }
+  next()
 }

--- a/src/routes/tool.routes.js
+++ b/src/routes/tool.routes.js
@@ -18,7 +18,7 @@ toolRouter.get('/:id', getToolByID, (_req, res) => {
 
 // search for tools and render the results with the dashboard view
 toolRouter.post('/search', sanitizeReqBody, searchTools, (_req, res) => {
-  res.render('dashboard')
+  res.render('results')
 })
 
 // retrieve current service assignment and render checkInOut prompting user to select the new assignment
@@ -27,17 +27,17 @@ toolRouter.post('/checkInOut', checkTools, (_req, res) => {
 })
 // save the new service assignement to the database.
 toolRouter.post('/submitCheckInOut', submitCheckInOut, (_req, res) => {
-  res.render('dashboard')
+  res.render('results')
 })
 
 // create new tool
 toolRouter.post('/submit', sanitizeReqBody, createTool, (_req, res) => {
-  res.render('dashboard')
+  res.render('results')
 })
 
 // update tool
 toolRouter.post('/update', sanitizeReqBody, updateTool, (_req, res) => {
-  res.render('dashboard')
+  res.render('results')
 })
 
 // archive tool

--- a/src/routes/tool.routes.js
+++ b/src/routes/tool.routes.js
@@ -8,16 +8,11 @@ import {
   updateTool,
   submitCheckInOut
 } from '../middleware/tool.js'
-import { sanitizeReqBody } from '../middleware/util.js'
+import { sanitizeReqBody, hoistSearchParamsToBody } from '../middleware/util.js'
 export const toolRouter = Router()
 
-// get tool by id
-toolRouter.get('/:id', getToolByID, (_req, res) => {
-  res.render('editTool')
-})
-
 // search for tools and render the results with the dashboard view
-toolRouter.post('/search', sanitizeReqBody, searchTools, (_req, res) => {
+toolRouter.use('/search', sanitizeReqBody, hoistSearchParamsToBody, searchTools, (_req, res) => {
   res.render('results')
 })
 
@@ -43,4 +38,9 @@ toolRouter.post('/update', sanitizeReqBody, updateTool, (_req, res) => {
 // archive tool
 toolRouter.get('/archive/:id', archiveTool, (_req, res) => {
   res.redirect('/dashboard')
+})
+
+// get tool by id
+toolRouter.get('/:id', getToolByID, (_req, res) => {
+  res.render('editTool')
 })

--- a/src/views/dashboard.hbs
+++ b/src/views/dashboard.hbs
@@ -1,48 +1,6 @@
-<div class="main-view z-0">
-  {{#if message}}
-    <div class="alert">{{message}}</div>
-  {{/if}}
-  {{#if searchTerms}}
-    <h1 id="search-terms">Searched For: <br />{{searchTerms}}</h1>
-  {{/if}}
-  <table class="table overflow-visible ">
-    <thead>
-      <tr>
-        <th>Serial number</th>
-        <th class="hidden md:table-cell">Tool ID</th>
-        <th>Barcode #</th>
-        <th class="hidden lg:table-cell">Description</th>
-        <th class="hidden lg:table-cell">Manufacturer</th>
-        <th class="hidden md:table-cell">Status</th>
-        <th class="hidden md:table-cell">Service Assignment</th>
-        <th class="hidden md:table-cell">Category</th>
-        <th>Edit</th>
-      </tr>
-    </thead>
-    {{#if tools}}
-      <tbody>
-        {{#each tools}}
-          {{#unless archived}}
-            <tr>
-              <td id="serialNumber">{{serialNumber}}</td>
-              <td class="hidden md:table-cell" id="modelNumber">{{toolID}}</td>
-              <td id="barcode">{{barcode}}</td>
-              <td class="hidden lg:table-cell" id="description">{{description}}</td>
-              <td class="hidden lg:table-cell" id="manufacturer">{{manufacturer}}</td>
-              <td class="hidden md:table-cell" id="status">{{status}}</td>
-              <td class="hidden md:table-cell" id="serviceAssignment">{{serviceAssignment.name}} -
-                {{serviceAssignment.description}}</td>
-              <td class="hidden md:table-cell" id="category">{{category.name}}
-              </td>
-              <td><label class="rounded-badge btn-xs"><a href="/tool/{{id}}"><i class="fa fa-pencil"></i></a></label>
-              </td>
-            </tr>
-          {{/unless}}
-        {{/each}}
-    {{/if}}
-    </tbody>
-  </table>
-</div>
+
+{{> _toolTable}}
+
 {{#if user.preferences.developer}}
 <div class="ml-10 pl-18 dropdown dropdown-right">
   <label tabindex="0" class="btn btn-circle btn-ghost btn-xs text-info">
@@ -94,4 +52,5 @@
 </div>
 <br />
 {{/if}}
+
 {{> _pagination}}

--- a/src/views/partials/_pagination.hbs
+++ b/src/views/partials/_pagination.hbs
@@ -2,20 +2,20 @@
 {{#gt pagination.pageCount 1}}
   <ul class="paginate-bar">
     {{#paginate pagination type="first"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">First</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">First</button></a></div>
     {{/paginate}}
     {{#paginate pagination type="previous"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">Previous</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">Previous</button></a></div>
     {{/paginate}}
     {{#paginate pagination type="middle" limit="9"}}
-      <div class="{{#if active}}active{{/if}} col"><a href="?p={{n}}"><button class="btn-paginate">{{n}}</button></a>
+      <div class="{{#if active}}active{{/if}} col"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">{{n}}</button></a>
       </div>
     {{/paginate}}
     {{#paginate pagination type="next"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">Next</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">Next</button></a></div>
     {{/paginate}}
     {{#paginate pagination type="last"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">Last</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">Last</button></a></div>
     {{/paginate}}
   </ul>
 {{/gt}}
@@ -24,14 +24,14 @@
 {{#gt pagination.pageCount 1}}
   <ul class="paginate-bar">
     {{#paginate pagination type="previous"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">Previous</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">Previous</button></a></div>
     {{/paginate}}
     {{#paginate pagination type="middle" limit="3"}}
-      <div class="{{#if active}}active{{/if}} col"><a href="?p={{n}}"><button class="btn-paginate">{{n}}</button></a>
+      <div class="{{#if active}}active{{/if}} col"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">{{n}}</button></a>
       </div>
     {{/paginate}}
     {{#paginate pagination type="next"}}
-      <div class="col-auto"><a href="?p={{n}}"><button class="btn-paginate">Next</button></a></div>
+      <div class="col-auto"><a href="?p={{n}}&searchBy={{@root.searchBy}}&searchTerm={{@root.searchTerm}}"><button class="btn-paginate">Next</button></a></div>
     {{/paginate}}
   </ul>
 {{/gt}}

--- a/src/views/partials/_toolTable.hbs
+++ b/src/views/partials/_toolTable.hbs
@@ -1,0 +1,39 @@
+<div class="main-view z-0">
+<table class="table overflow-visible ">
+    <thead>
+      <tr>
+        <th>Serial number</th>
+        <th class="hidden md:table-cell">Tool ID</th>
+        <th>Barcode #</th>
+        <th class="hidden lg:table-cell">Description</th>
+        <th class="hidden lg:table-cell">Manufacturer</th>
+        <th class="hidden md:table-cell">Status</th>
+        <th class="hidden md:table-cell">Service Assignment</th>
+        <th class="hidden md:table-cell">Category</th>
+        <th>Edit</th>
+      </tr>
+    </thead>
+    {{#if tools}}
+      <tbody>
+        {{#each tools}}
+          {{#unless archived}}
+            <tr>
+              <td id="serialNumber">{{serialNumber}}</td>
+              <td class="hidden md:table-cell" id="modelNumber">{{toolID}}</td>
+              <td id="barcode">{{barcode}}</td>
+              <td class="hidden lg:table-cell" id="description">{{description}}</td>
+              <td class="hidden lg:table-cell" id="manufacturer">{{manufacturer}}</td>
+              <td class="hidden md:table-cell" id="status">{{status}}</td>
+              <td class="hidden md:table-cell" id="serviceAssignment">{{serviceAssignment.name}} -
+                {{serviceAssignment.description}}</td>
+              <td class="hidden md:table-cell" id="category">{{category.name}}
+              </td>
+              <td><label class="rounded-badge btn-xs"><a href="/tool/{{id}}"><i class="fa fa-pencil"></i></a></label>
+              </td>
+            </tr>
+          {{/unless}}
+        {{/each}}
+    {{/if}}
+    </tbody>
+  </table>
+  </div>

--- a/src/views/results.hbs
+++ b/src/views/results.hbs
@@ -1,0 +1,11 @@
+<div class="main-view z-0">
+  {{#if message}}
+    <div class="alert">{{message}}</div>
+  {{/if}}
+  {{#if searchTerm}}
+    <h1 class="text-2xl" id="search-terms">Searched For: {{searchTerm}}.  Total Results: {{tools.length}}</h1>
+  {{/if}}
+  {{> _toolTable}}
+</div>
+
+{{> _pagination}}

--- a/src/views/results.hbs
+++ b/src/views/results.hbs
@@ -1,4 +1,4 @@
-<div class="main-view z-0">
+
   {{#if message}}
     <div class="alert">{{message}}</div>
   {{/if}}
@@ -6,6 +6,6 @@
     <h1 class="text-2xl" id="search-terms">Searched For: {{searchTerm}}.  Total Results: {{tools.length}}</h1>
   {{/if}}
   {{> _toolTable}}
-</div>
+
 
 {{> _pagination}}


### PR DESCRIPTION
Pagination buttons now contain URL query parameters via key-value pairs for the search terms and field searched. 

toolTable.hbs has been moved to a partial to make it more reusable. 

the dev script in package.json has concurrently removed as it prevents 'rs' from restarting nodemon

the searchTool middleware has been modified to use a switch/case based on the field searched, and execute the search accordingly. ServiceAssignment and Category both use the OID BSON value of the searched value. the remaining options (SN, Model, Manuf, tool-id) use regex to search the string.

a utility middleware function has been added to hoist the search parameters from url-query to request body, so it will persist between page navigation after a search.