### PR TITLE
toolCountChanges

### DIFF
--- a/src/middleware/serviceAssignment.js
+++ b/src/middleware/serviceAssignment.js
@@ -13,7 +13,7 @@ import { mutateToArray } from './util.js'
 export async function getServiceAssignments(req, res, next) {
   logger.info('[MW] getServiceAssignments-in'.bgBlue.white)
   try {
-    const serviceAssignments = await ServiceAssignment.find().sort('name').exec()
+    const serviceAssignments = await ServiceAssignment.find().sort('name').lean()
 
     res.locals.inactiveServiceAssignments = serviceAssignments.filter((item) => { return item.active === false })
     res.locals.activeServiceAssignments = serviceAssignments.filter((item) => { return item.active === true })

--- a/src/models/ServiceAssignment.model.js
+++ b/src/models/ServiceAssignment.model.js
@@ -1,4 +1,4 @@
-import { Schema, model } from 'mongoose'
+import mongoose, { Schema, model } from 'mongoose'
 
 const ServiceAssignmentSchema = new Schema(
   {
@@ -18,8 +18,8 @@ const ServiceAssignmentSchema = new Schema(
     type: {
       type: String,
       enum: [
-        'Contract Job',
-        'Service Job',
+        'Contract Jobsite',
+        'Service Jobsite',
         'Stockroom',
         'Vehicle',
         'Employee',
@@ -33,6 +33,11 @@ const ServiceAssignmentSchema = new Schema(
     },
     phone: {
       type: String
+    },
+    toolCount: {
+      type: Number,
+      default: 0,
+      min: 0
     },
     notes: {
       type: String

--- a/src/scripts/updateToolCounts.js
+++ b/src/scripts/updateToolCounts.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+import Tool from '../models/Tool.model.js';
+import ServiceAssignment from '../models/ServiceAssignment.model.js';
+
+// Connect to your MongoDB database
+mongoose.connect('mongodb://mongo.ado.lan:27017/toolkeeper?authSource=admin', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+async function updateToolCounts() {
+  try {
+    // Get all service assignments
+    const serviceAssignments = await ServiceAssignment.find({});
+    
+    for (const assignment of serviceAssignments) {
+      // Count the number of tools assigned to each service assignment
+      const toolCount = await Tool.countDocuments({ serviceAssignment: assignment?._id });
+
+      // Update the toolCount field of the service assignment
+      assignment.toolCount = toolCount;
+      await assignment.save();
+    }
+
+    console.log('Tool counts have been updated successfully');
+  } catch (error) {
+    console.error('Error updating tool counts:', error);
+  } finally {
+    mongoose.connection.close();
+  }
+}
+
+// Run the script
+updateToolCounts();

--- a/src/views/settings/serviceAssignments.hbs
+++ b/src/views/settings/serviceAssignments.hbs
@@ -14,6 +14,7 @@
                 <table class="table table-auto">
                     <thead>
                         <tr>
+                            <th>Tool Count</th>
                             <th>Display Name</th>
                             <th class="hidden md:table-cell">Description</th>
                             <th>Edit</th>
@@ -24,6 +25,7 @@
                         {{#if activeServiceAssignments}}
                         {{#each activeServiceAssignments}}
                         <tr>
+                            <td>{{toolCount}}</td>
                             <td>{{name}}</td>
                             <td class="hidden md:table-cell min-w-fit">{{description}}</td>
                             <td><a href="/settings/serviceAssignments/edit/{{id}}"><i class="fa fa-pencil"></i></a></td>
@@ -49,6 +51,7 @@
                             <th>Activate</th>
                             <th>Display Name</th>
                             <th class="hidden md:table-cell">Description</th>
+                            <th class="hidden md:table-cell">Tool Count</th>
                             <th>Edit</th>
                             <th>Delete</th>
                         </tr>
@@ -61,6 +64,7 @@
                                         class="fas fa-arrow-left"></i></a></td>
                             <td>{{name}}</td>
                             <td class="hidden md:table-cell min-w-fit">{{description}}</td>
+                            <td {{#gt toolCount 0 }}class="text-red-400 font-semibold"{{/gt}}>{{toolCount}}</td>
                             <td><a href="/settings/serviceAssignments/edit/{{id}}"><i class="fa fa-pencil"></i></a></td>
                             <td><a href="/settings/serviceAssignments/delete/{{id}}"
                                     onclick="return confirm('Are you sure you want to delete {{name}}')"><i


### PR DESCRIPTION
Subject: Enhance Service Assignment with Tool Count

Added 'toolCount' field to ServiceAssignment model for better resource tracking, enforcing a minimum value of 0 to ensure data integrity. Updated the enum values within the ServiceAssignment Schema to more accurately reflect the types of jobsites, changing 'Contract Job' and 'Service Job' to 'Contract Jobsite' and 'Service Jobsite,' respectively. This change clarifies the nature of the assignments in the system. Service assignment fetch operation is now more performance-efficient by using `.lean()` with the query to speed up data retrieval, beneficial for large datasets. Furthermore, the 'toolCount' field is now displayed in the service assignments settings view, with a visual emphasis on counts greater than zero, improving the user interface for site administrators by allowing quick identification of resource allocations per assignment.

This integration offers a detailed insight into the resource distribution across different service assignments, facilitating better planning and resource management.

Resolves:  add toolCount to ServiceAssignment model and settings page. #187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DaveLuhman/toolkeeper/188)
<!-- Reviewable:end -->
