### PR TITLE
Fix category update issues

### DIFF
--- a/src/middleware/category.js
+++ b/src/middleware/category.js
@@ -45,8 +45,8 @@ const updateCategory = async function (req, res, next) {
   const { _id, name, description } = req.body
   try {
     const updatedCategory = await Category.findByIdAndUpdate(
-      { id: { $eq: _id } },
-      { name: { $eq: name }, description: { $eq: description } },
+      { _id },
+      { name, description},
       { new: true }
     )
     res.locals.updatedCategory = updatedCategory

--- a/src/routes/settings/category.routes.js
+++ b/src/routes/settings/category.routes.js
@@ -23,6 +23,7 @@ categoryRouter.post(
   '/edit', // target
   sanitizeReqBody,
   updateCategory,
+  getCategories,
   renderSettingsCategories
 )
 // add new service assignment


### PR DESCRIPTION
This pull request fixes the issue with updating category names. The $eq operator has been removed from the update query as it is only required before sanitization. Additionally, a call to getCategories has been added after updating an item to ensure that the old values do not appear until a refresh is performed. Fixes #232.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DaveLuhman/toolkeeper/237)
<!-- Reviewable:end -->
