### PR TITLE
Fix tool archiving URL in editTool.hbs

### DIFF
--- a/src/views/editTool.hbs
+++ b/src/views/editTool.hbs
@@ -154,7 +154,7 @@
         {
             e.preventDefault()
             if(window.confirm('Would you like to archive this tool?')) {
-                window.location.href = '/tool/archive/{{id}}'
+                window.location.href = '/tool/archive/{{tools.0.id}}'
             }
         })
     }


### PR DESCRIPTION
This pull request fixes the issue where the tool archiving URL in the editTool.hbs template was not using the correct tool ID. The commit "fix: Update tool archive URL to use correct tool ID" updates the URL to replace the placeholder "{{id}}" with the actual tool ID "{{tools.0.id}}". This change ensures that the correct tool is archived when the user confirms the action.

Fixes #233

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/DaveLuhman/toolkeeper/238)
<!-- Reviewable:end -->
