### PR TITLE
Fix typo in user limit determination variable name in user middleware

### DIFF
--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -82,7 +82,7 @@ const createUserInTenant = async (req, res, next) => {
 
 		// Determine user limit using the external function
 		const { userLimit, planName } = determineUserLimit(
-			subscriptionDoc.lemonSqueezyObject.variantName,
+			subscriptionDoc.lemonSqueezyObject.variant_name,
 		);
 
 		if (currentUserCount >= userLimit) {


### PR DESCRIPTION
VariantName has been corrected to variant_name to match snake_case like the rest of the LS api